### PR TITLE
DO NOT USE. Feat[launcher]: start implementing custom JVM launcher

### DIFF
--- a/app_pojavlauncher/src/main/java/com/oracle/dalvik/VMLauncher.java
+++ b/app_pojavlauncher/src/main/java/com/oracle/dalvik/VMLauncher.java
@@ -3,5 +3,5 @@ package com.oracle.dalvik;
 public final class VMLauncher {
 	private VMLauncher() {
 	}
-	public static native int launchJVM(String[] args);
+	public static native void launchJVM(String jvmPath, String[] vmArgs, String classpath, String mainClass, String[] applicationArgs);
 }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/JavaGUILauncherActivity.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/JavaGUILauncherActivity.java
@@ -327,7 +327,7 @@ public class JavaGUILauncherActivity extends BaseActivity implements View.OnTouc
 
             Logger.appendToLog("Info: Java arguments: " + Arrays.toString(javaArgList.toArray(new String[0])));
 
-            JREUtils.launchJavaVM(this, runtime,null,javaArgList, LauncherPreferences.PREF_CUSTOM_JAVA_ARGS);
+            //JREUtils.launchJavaVM(this, runtime,null,javaArgList, LauncherPreferences.PREF_CUSTOM_JAVA_ARGS);
         } catch (Throwable th) {
             Tools.showError(this, th, true);
         }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/Tools.java
@@ -210,16 +210,25 @@ public final class Tools {
             javaArgList.add("-Dlog4j.configurationFile=" + configFile);
         }
         javaArgList.addAll(Arrays.asList(getMinecraftJVMArgs(versionId, gamedir)));
-        javaArgList.add("-cp");
-        javaArgList.add(getLWJGL3ClassPath() + ":" + launchClassPath);
+        //javaArgList.add("-cp");
+        //javaArgList.add(getLWJGL3ClassPath() + ":" + launchClassPath);
 
-        javaArgList.add(versionInfo.mainClass);
-        javaArgList.addAll(Arrays.asList(launchArgs));
+        //javaArgList.add(versionInfo.mainClass);
+        //javaArgList.addAll(Arrays.asList(launchArgs));
         // ctx.appendlnToLog("full args: "+javaArgList.toString());
         String args = LauncherPreferences.PREF_CUSTOM_JAVA_ARGS;
         if(Tools.isValidString(minecraftProfile.javaArgs)) args = minecraftProfile.javaArgs;
         FFmpegPlugin.discover(activity);
-        JREUtils.launchJavaVM(activity, runtime, gamedir, javaArgList, args);
+        JREUtils.launchJavaVM(
+                activity,
+                runtime,
+                gamedir,
+                javaArgList,
+                getLWJGL3ClassPath() + ":" + launchClassPath,
+                versionInfo.mainClass,
+                launchArgs,
+                args
+        );
         // If we returned, this means that the JVM exit dialog has been shown and we don't need to be active anymore.
         // We never return otherwise. The process will be killed anyway, and thus we will become inactive
     }

--- a/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
+++ b/app_pojavlauncher/src/main/java/net/kdt/pojavlaunch/utils/JREUtils.java
@@ -273,7 +273,14 @@ public class JREUtils {
         // return ldLibraryPath;
     }
 
-    public static void launchJavaVM(final AppCompatActivity activity, final Runtime runtime, File gameDirectory, final List<String> JVMArgs, final String userArgsString) throws Throwable {
+    public static void launchJavaVM(final AppCompatActivity activity,
+                                    final Runtime runtime,
+                                    File gameDirectory,
+                                    final List<String> JVMArgs,
+                                    final String classpath,
+                                    final String mainClass,
+                                    final String[] appArgs,
+                                    final String userArgsString) throws Throwable {
         String runtimeHome = MultiRTUtils.getRuntimeHome(runtime.name).getAbsolutePath();
 
         JREUtils.relocateLibPath(runtime, runtimeHome);
@@ -306,17 +313,9 @@ public class JREUtils {
         initJavaRuntime(runtimeHome);
         setupExitTrap(activity.getApplication());
         chdir(gameDirectory == null ? Tools.DIR_GAME_NEW : gameDirectory.getAbsolutePath());
-        userArgs.add(0,"java"); //argv[0] is the program name according to C standard.
 
-        final int exitCode = VMLauncher.launchJVM(userArgs.toArray(new String[0]));
-        Logger.appendToLog("Java Exit code: " + exitCode);
-        if (exitCode != 0) {
-            LifecycleAwareAlertDialog.DialogCreator dialogCreator = (dialog, builder)->
-                    builder.setMessage(activity.getString(R.string.mcn_exit_title, exitCode))
-                    .setPositiveButton(R.string.main_share_logs, (dialogInterface, which)-> shareLog(activity));
+        VMLauncher.launchJVM(jvmLibraryPath+"/libjvm.so", userArgs.toArray(new String[0]), classpath, mainClass.replace('.', '/'), appArgs);
 
-            LifecycleAwareAlertDialog.haltOnDialog(activity.getLifecycle(), activity, dialogCreator);
-        }
         MainActivity.fullyExit();
     }
 

--- a/app_pojavlauncher/src/main/jni/utils.c
+++ b/app_pojavlauncher/src/main/jni/utils.c
@@ -13,6 +13,19 @@ typedef void (*android_update_LD_LIBRARY_PATH_t)(char*);
 
 long shared_awt_surface;
 
+bool scopeAttach(JavaVM* vm, scope_t *scope) {
+	jint err = (*vm)->GetEnv(vm, (void**)&scope->env, JNI_VERSION_1_6);
+	if(err == JNI_EDETACHED) {
+		err = (*vm)->AttachCurrentThread(vm, &scope->env, NULL);
+		if(err == JNI_OK) scope->detach = true;
+	}
+	return err == JNI_OK;
+}
+
+void scopeDetach(JavaVM* vm, scope_t *scope) {
+	if(scope->detach) (*vm)->DetachCurrentThread(vm);
+}
+
 char** convert_to_char_array(JNIEnv *env, jobjectArray jstringArray) {
 	int num_rows = (*env)->GetArrayLength(env, jstringArray);
 	char **cArray = (char **) malloc(num_rows * sizeof(char*));

--- a/app_pojavlauncher/src/main/jni/utils.h
+++ b/app_pojavlauncher/src/main/jni/utils.h
@@ -2,7 +2,13 @@
 
 #include <stdbool.h>
 
+typedef struct {
+    bool detach;
+    JNIEnv *env;
+} scope_t;
 
+bool scopeAttach(JavaVM*, scope_t*);
+void scopeDetach(JavaVM*, scope_t*);
 
 char** convert_to_char_array(JNIEnv *env, jobjectArray jstringArray);
 jobjectArray convert_from_char_array(JNIEnv *env, char **charArray, int num_rows);


### PR DESCRIPTION
Why do this:
1. This will allow us to fully move argument parsing to Java and skips headroom of parsing the arguments again by the Java's libjli launcher.
2. This removes a lot of implementation quirks of JLI, like the ones related to JVM path resolution.

TODO for this to be complete:
1. Transform module-related arguemnts (they need to be in their `=` form for the JVM)
2. Handle `-XX:` style arguments